### PR TITLE
Stream stdout from functions

### DIFF
--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -197,11 +197,16 @@ def handler(event, context):
     local_env.update(extra_env)
 
     print "command str=", cmdstr
-    process = subprocess.Popen(cmdstr, shell=True, env=local_env, bugsize=1, stdout=subprocess.PIPE)
+    # This is copied from http://stackoverflow.com/a/17698359/4577954
+    process = subprocess.Popen(cmdstr, shell=True, env=local_env, bufsize=1, stdout=subprocess.PIPE)
+    stdout = ''
     with process.stdout:
-        for line in iter(process.stdout.readline, b'')
-          print line
+        for line in iter(process.stdout.readline, b''):
+            stdout += line
+            print line,
 
+    # TODO(shivaram): It looks like the deadlock warning in subprocess should not apply here
+    # as we drain the stdout before calling wait ?
     process.wait()
     print "command execution finished"
 

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -197,8 +197,13 @@ def handler(event, context):
     local_env.update(extra_env)
 
     print "command str=", cmdstr
-    stdout = subprocess.check_output(cmdstr, shell=True, env=local_env)
-    print "command executed, stdout=", stdout
+    process = subprocess.Popen(cmdstr, shell=True, env=local_env, bugsize=1, stdout=subprocess.PIPE)
+    with process.stdout:
+        for line in iter(process.stdout.readline, b'')
+          print line
+
+    process.wait()
+    print "command execution finished"
 
     s3.meta.client.upload_file(output_filename, output_key[0], 
                                output_key[1])


### PR DESCRIPTION
This PR changes the `subprocess` call to stream the contents of stdout. For longer running lambdas this means that cloud watch will now show output while it runs.