### PR TITLE
PyPI staging and release setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy pytest cython nose boto3 PyYAML Click pytest
   - source activate test-environment
   - pip install glob2
-  - python setup.py install
+  - tests/install_pywren.sh
 
 
   

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 Eric Jonas <jonas@ericjonas.com>
 Shivaram Venkataraman <shivaram.venkataraman@gmail.com>
 Matthew Landowski <matthew.landowski@gmail.com>
+Qifan Pu <qifan@cs.berkeley.edu> 

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -119,12 +119,18 @@ for final releases.
 2. Make sure everything is passing on travis
 
 3. push to pypitest
-
+First make sure you are setup
 ```
 python setup.py register -r pypitest
+```
+
+```
 python setup.py sdist upload -r pypitest
 ```
 4. Test the pypitest build by updating the tag `pypitest-build` to the current build
+
+5. Kickoff the travis build for this version by deleting and reupdating the tag. I know
+this is a bit of a hack, but it works. 
 
 ```
 # delete the remote tag

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -127,7 +127,14 @@ python setup.py sdist upload -r pypitest
 4. Test the pypitest build by updating the tag `pypitest-build` to the current build
 
 ```
-git push -f origin :refs/heads/pypitest-build
+# delete the remote tag
+git push -f origin :refs/tags/pypitest-build
+# delete local 
+git tag -d pypitest-build
+# create tag
+git tag pypitest-build
+# push
+git push origin --tags
 ```
 
 4. Create a github release via the gui

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -66,10 +66,23 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/EC2NewInstanceCWL.html
 
 
 ## How to release with PyPi:
+I am mostly following http://peterdowns.com/posts/first-time-with-pypi.html . I had
+been using twine but it looks like, with the latest versions of python, 
+twine is unnessary. 
+
+Make sure you create a `~/.pypirc` file. 
+
+First register
 ```
-python setup.py bdist_wheel
-twine register dist/
+python setup.py register -r pypitest
 ```
+
+Test on pypi-test
+```
+python setup.py sdist upload -r pypitest
+```
+
+
 
 note that travis has support for auto-releasing this, which we should investigate
 
@@ -95,3 +108,29 @@ pip install -e pywren
 
 ## The runtime
 The runtime is a tremendous challenge
+
+## How to release:
+
+We use a release versioning scheme of 0.1rc0 for dev releases and 0.1
+for final releases.
+
+1. Tag the release, via magit you can do this via the tags popup. Push the tags to github via `P` `t` from the `magit status buffer`
+
+2. Make sure everything is passing on travis
+
+3. push to pypitest
+
+```
+python setup.py register -r pypitest
+python setup.py sdist upload -r pypitest
+```
+
+4. Create a github release via the gui
+
+5. push to pypi
+
+```
+python setup.py register -r pypi
+python setup.py sdist upload -r pypi
+```
+

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -124,6 +124,11 @@ for final releases.
 python setup.py register -r pypitest
 python setup.py sdist upload -r pypitest
 ```
+4. Test the pypitest build by updating the tag `pypitest-build` to the current build
+
+```
+git push -f origin :refs/heads/pypitest-build
+```
 
 4. Create a github release via the gui
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include README.md
-include default_config.yaml
+include pywren/default_config.yaml
+include pywren/ec2_standalone_files/ec2standalone.cloudinit.template
+include pywren/ec2_standalone_files/supervisord.conf
+include pywren/ec2_standalone_files/supervisord.init
+include pywren/ec2_standalone_files/cloudwatch-agent.config

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
-__version__ = "0.0.4rc1"
+__version__ = "0.0.4rc2"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -1,4 +1,8 @@
+from __future__ import print_function
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
 __version__ = "0.0.4rc1"
+
+if __name__ == "__main__":
+    print(__version__)

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -1,4 +1,4 @@
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
-__version__ = "0.1rc0"
+__version__ = "0.0.3rc1"

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
-__version__ = "0.0.4rc2"
+__version__ = "0.0.4rc3"
 
 if __name__ == "__main__":
     print(__version__)

--- a/pywren/version.py
+++ b/pywren/version.py
@@ -1,4 +1,4 @@
 # we're following the version number guidelines
 # from https://www.python.org/dev/peps/pep-0386/
 
-__version__ = "0.0.3rc1"
+__version__ = "0.0.4rc1"

--- a/pywren/wrenconfig.py
+++ b/pywren/wrenconfig.py
@@ -21,9 +21,6 @@ FUNCTION_NAME = "pywren1"
 
 MAX_AGG_DATA_SIZE = 4e6
 
-DEFAULT_PYTHON2_RUNTIME="pywren.runtime/pywren_runtime-2-default_2.tar.gz"
-DEFAULT_PYTHON3_RUNTIME="pywren.runtime/pywren_runtime-3-default_3.tar.gz"
-
 default_runtime = {'2.7' : "pywren.runtime/pywren_runtime-2.7-default.tar.gz", 
                    '3.5' : "pywren.runtime/pywren_runtime-3.5-default.tar.gz", 
                    '3.6' : "pywren.runtime/pywren_runtime-3.6-default.tar.gz"}

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@ exec(open('pywren/version.py').read())
 setup(
     name='pywren',
     version=__version__,
-    url='https://github.com/ericmjonas/github',
+    url='https://github.com/ericmjonas/pywren',
     author='Eric Jonas',
+    description='Run many jobs transparently on AWS Lambda and other cloud services',
+    long_description="PyWren lets you transparently run your python functions on AWS cloud services, including AWS Lambda and AWS EC2.", 
     author_email='jonas@ericjonas.com',
     packages=['pywren', 'pywren.scripts', 'pywren.cloudpickle'],
     install_requires=[
@@ -23,8 +25,8 @@ setup(
     ],
     entry_points =
     { 'console_scripts' : ['pywren=pywren.scripts.pywrencli:cli', 
-                           'pywren-server=pywren.scripts.standalone:server']},
-    package_data={'pywren': ['default_config.yaml', 
+                           'pywren-server=pywren.scrirpts.standalone:server']},
+    package_data={'pywren': ['config_default.yaml', 
                              'ec2_standalone_files/ec2standalone.cloudinit.template', 
                              'ec2_standalone_files/supervisord.conf', 
                              'ec2_standalone_files/supervisord.init', 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     entry_points =
     { 'console_scripts' : ['pywren=pywren.scripts.pywrencli:cli', 
                            'pywren-server=pywren.scrirpts.standalone:server']},
-    package_data={'pywren': ['config_default.yaml', 
+    package_data={'pywren': ['default_config.yaml', 
                              'ec2_standalone_files/ec2standalone.cloudinit.template', 
                              'ec2_standalone_files/supervisord.conf', 
                              'ec2_standalone_files/supervisord.init', 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description='Run many jobs transparently on AWS Lambda and other cloud services',
     long_description="PyWren lets you transparently run your python functions on AWS cloud services, including AWS Lambda and AWS EC2.", 
     author_email='jonas@ericjonas.com',
-    packages=['pywren', 'pywren.scripts', 'pywren.cloudpickle'],
+    packages=find_packages(),
     install_requires=[
         'numpy', 'Click', 'boto3', 'cloudpickle', 'PyYAML', 
         'enum34', 'flaky', 'glob2', 'multiprocess', 
@@ -25,7 +25,7 @@ setup(
     ],
     entry_points =
     { 'console_scripts' : ['pywren=pywren.scripts.pywrencli:cli', 
-                           'pywren-server=pywren.scrirpts.standalone:server']},
+                           'pywren-server=pywren.scripts.standalone:server']},
     package_data={'pywren': ['default_config.yaml', 
                              'ec2_standalone_files/ec2standalone.cloudinit.template', 
                              'ec2_standalone_files/supervisord.conf', 

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -3,7 +3,7 @@
 set -ev
 # this is a script that either installs the local pywren from source
 # or downloads from pypy depending on the branch name
-if [ ${TRAVIS_BRANCH} = "pypitest-build" ]; then
+if [ ${TRAVIS_TAG} = "pypitest-build" ]; then
     rm -Rf pywren
     pip install -i https://testpypi.python.org/pypi pywren
 else

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -3,7 +3,7 @@
 set -ev
 # this is a script that either installs the local pywren from source
 # or downloads from pypy depending on the branch name
-if [ ${TRAVIS_TAG} = "pypitest-build" ]; then
+if [ "$TRAVIS_TAG" = "pypitest-build" ]; then
     echo "installing from pypitest"; 
     rm -Rf pywren; 
     pip install --extra-index-url https://testpypi.python.org/pypi pywren; 

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -5,7 +5,7 @@ set -ev
 # or downloads from pypy depending on the branch name
 if [ ${TRAVIS_TAG} = "pypitest-build" ]; then
     rm -Rf pywren
-    pip install -i https://testpypi.python.org/pypi pywren
+    pip install --extra-index-url https://testpypi.python.org/pypi pywren
 else
     python setup.py install
 fi

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -4,10 +4,12 @@ set -ev
 # this is a script that either installs the local pywren from source
 # or downloads from pypy depending on the branch name
 if [ ${TRAVIS_TAG} = "pypitest-build" ]; then
-    rm -Rf pywren
-    pip install --extra-index-url https://testpypi.python.org/pypi pywren
+    echo "installing from pypitest"; 
+    rm -Rf pywren; 
+    pip install --extra-index-url https://testpypi.python.org/pypi pywren; 
 else
-    python setup.py install
+    echo "installing from git"; 
+    python setup.py install; 
 fi
 
 exit 0;

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -4,9 +4,10 @@ set -ev
 # this is a script that either installs the local pywren from source
 # or downloads from pypy depending on the branch name
 if [ "$TRAVIS_TAG" = "pypitest-build" ]; then
-    echo "installing from pypitest"; 
-    rm -Rf pywren; 
-    pip install --extra-index-url https://testpypi.python.org/pypi pywren; 
+    echo "installing from pypitest";
+    cp pywren/version.py print_version.py; 
+    rm -Rf pywren; # make sure we aren't touching git code
+    pip install --extra-index-url https://testpypi.python.org/pypi pywren==`python print_version.py`
 else
     echo "installing from git"; 
     python setup.py install; 

--- a/tests/install_pywren.sh
+++ b/tests/install_pywren.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ev
+# this is a script that either installs the local pywren from source
+# or downloads from pypy depending on the branch name
+if [ ${TRAVIS_BRANCH} = "pypitest-build" ]; then
+    rm -Rf pywren
+    pip install -i https://testpypi.python.org/pypi pywren
+else
+    python setup.py install
+fi
+
+exit 0;


### PR DESCRIPTION
This is a super-noisy PR but reflects cleaning up all the mechanics around releases

- Getting `setup.py` metadata correct
- Creating a section on how to release in DEVNOTES
- Adding a process for testing a pypi package staged to pypitesting before pushing the final version, involving triggering our existing travis infrastructure , and indicating this should happen by pushing a new tag.

