### PR TITLE
Handle un-pickleable exceptions

### DIFF
--- a/examples/run_command.py
+++ b/examples/run_command.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 def run_command(x):
-    subprocess.check_output(x, shell=True).decode('ascii')
+    return subprocess.check_output(x, shell=True).decode('ascii')
 
 if __name__ == "__main__":
     cmd = " ".join(sys.argv[1:])

--- a/examples/run_command.py
+++ b/examples/run_command.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 def run_command(x):
-    return subprocess.check_output(x, shell=True).decode('ascii')
+    subprocess.check_output(x, shell=True).decode('ascii')
 
 if __name__ == "__main__":
     cmd = " ".join(sys.argv[1:])

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -38,11 +38,34 @@ try:
 except Exception as e:
     exc_type, exc_value, exc_traceback = sys.exc_info()
     traceback.print_tb(exc_traceback)
-    pickle.dump({'result' : e, 
-                 'exc_type' : exc_type, 
-                 'exc_value' : exc_value, 
-                 'exc_traceback' : exc_traceback, 
-                 'sys.path' : sys.path, 
-                 'success' : False}, 
-                open(out_filename, 'wb'), -1)
+
+    # Shockingly often, modules like subprocess don't properly 
+    # call the base Exception.__init__, which results in them 
+    # being unpickleable. As a result, we actually wrap this in a try/catch block
+    # and more-carefully handle the exceptions if any part of this save / test-reload
+    # fails
+
+    try:
+        pickle.dump({'result' : e, 
+                     'exc_type' : exc_type, 
+                     'exc_value' : exc_value, 
+                     'exc_traceback' : exc_traceback, 
+                     'sys.path' : sys.path, 
+                     'success' : False}, 
+                    open(out_filename, 'wb'), -1)
+        # this is just to make sure they can be unpickled
+        pickle.load(open(out_filename, 'rb'))
+
+    except Exception as pickle_exception:
+        pickle.dump({'result' : str(e), 
+                     'exc_type' : str(exc_type), 
+                     'exc_value' : str(exc_value), 
+                     'exc_traceback' : exc_traceback, 
+                     'exc_traceback_str' : str(exc_traceback), 
+                     'sys.path' : sys.path, 
+                     'pickle_fail' : True, 
+                     'pickle_exception' : pickle_exception, 
+                     'success' : False}, 
+                    open(out_filename, 'wb'), -1)
+        
     

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -539,6 +539,7 @@ class ResponseFuture(object):
                 raise Exception(exception_str, *exception_args)
         
         call_output_time = time.time()
+        print("calling get_call_output")
         call_invoker_result = get_call_output(self.callset_id, self.call_id, 
                                               AWS_S3_BUCKET = self.s3_bucket, 
                                               AWS_S3_PREFIX = self.s3_prefix,
@@ -556,28 +557,36 @@ class ResponseFuture(object):
 
         self._call_invoker_result = call_invoker_result
 
+        self.run_status = call_status # this is the remote status information
+        self.invoke_status = self._invoke_metadata # local status information
+
+
         if call_success:
 
             self._return_val = call_invoker_result['result']
             self._state = JobState.success
-        else:
+            return self._return_val
+
+        elif call_success == False and throw_except:
+
             self._exception = call_invoker_result['result']
             self._traceback = (call_invoker_result['exc_type'], 
                                call_invoker_result['exc_value'], 
                                call_invoker_result['exc_traceback'])
 
             self._state = JobState.error
+            if call_invoker_result.get('pickle_fail', False):
+                logging.warning("there was an error pickling the resulting exception: {}".format(call_invoker_result['exc_value']))
 
+                reraise(Exception, call_invoker_result['exc_value'], 
+                        call_invoker_result['exc_traceback'])
+                #raise pickle.PickleError("there was an error pickling the resulting exception, whose value was {}".format(call_invoker_result['exc_value']))
 
-
-        self.run_status = call_status # this is the remote status information
-        self.invoke_status = self._invoke_metadata # local status information
-
-        if call_success:
-            return self._return_val
-        elif call_success == False and throw_except:
-            reraise(*self._traceback)
-        return None
+            else:
+                # reraise the exception
+                reraise(*self._traceback)
+        else:
+            return None  # nothing, don't raise, no value
             
     def exception(self, timeout = None):
         raise NotImplementedError()

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,162 @@
+import pytest
+import time
+import boto3 
+import uuid
+import numpy as np
+import time
+import pywren
+import pywren.runtime
+import subprocess
+import logging
+from six.moves import cPickle as pickle
+
+import unittest
+import numpy as np
+from flaky import flaky
+import sys
+
+
+class CantPickle(object):
+    """
+    Some objects can't be pickled, and either fail at
+    save or restore. We need to catch these and, as
+    the Hydraulic press guy says, "deal with it" 
+    """
+
+    def __init__(self, foo, dump_fail=False, load_fail=False):
+        self.foo = foo
+        self.dump_fail = dump_fail
+        self.load_fail = load_fail
+    
+    def __getstate__(self):
+        print("getstate called")
+        if self.dump_fail:
+            raise Exception("cannot pickle dump this object")
+
+        return {'foo' : self.foo, 
+                'dump_fail' : self.dump_fail, 
+                'load_fail' : self.load_fail}
+
+    def __setstate__(self, arg):
+        print("setstate called")
+        if arg['load_fail']:
+            raise Exception("cannot pickle load this object")
+
+        self.load_fail = arg['load_fail']
+        self.dump_fail = arg['dump_fail']
+        self.foo = arg['foo']
+
+class CantPickleException(Exception):
+    """
+    Some objects can't be pickled, and either fail at
+    save or restore. We need to catch these and, as
+    the Hydraulic press guy says, "deal with it" 
+    """
+
+    def __init__(self, foo, dump_fail=False, load_fail=False, 
+                 skip_super = False):
+        if not skip_super :
+            super(Exception, self).__init__(str(foo))
+        self.foo = foo
+        self.dump_fail = dump_fail
+        self.load_fail = load_fail
+        
+
+    def __getstate__(self):
+        print("getstate called")
+        if self.dump_fail:
+            raise Exception("cannot pickle dump this object")
+
+        return {'foo' : self.foo, 
+                'dump_fail' : self.dump_fail, 
+                'load_fail' : self.load_fail}
+
+    def __setstate__(self, arg):
+        print("setstate called")
+        if arg['load_fail']:
+            raise Exception("cannot pickle load this object")
+
+        self.load_fail = arg['load_fail']
+        self.dump_fail = arg['dump_fail']
+        self.foo = arg['foo']
+
+class PickleSafety(unittest.TestCase):
+
+    def setUp(self):
+        self.wrenexec = pywren.default_executor()
+
+    def test_subprocess_fail(self):
+        """
+        Subprocess command-not-found fails
+        """
+        def uname(x):
+            return subprocess.check_output("fakecommand", shell=True)
+
+        
+        fut = self.wrenexec.call_async(uname, None)
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+        assert "Command 'fakecommand' returned" in str(execinfo.value)
+    
+    def test_unpickleable_return_dump(self):
+        def f(x):
+            cp = CantPickle(x, dump_fail = True)
+            return cp
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(f, None)
+
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+        print(str(execinfo.value))
+        assert 'cannot pickle dump this object' in str(execinfo.value)
+
+    def test_unpickleable_return_load(self):
+        def f(x):
+            cp = CantPickle(x, load_fail = True)
+            return cp
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(f, None)
+
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+        assert 'cannot pickle load this object' in str(execinfo.value)
+        
+
+    def test_unpickleable_raise_except_dump(self):
+        def f(x):
+            cp = CantPickleException(x, dump_fail = True)
+            raise cp
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(f, None)
+
+        with pytest.raises(CantPickleException) as execinfo:
+            res = fut.result() 
+        #assert 'cannot pickle dump this object' in str(execinfo.value)
+
+
+    def test_unpickleable_raise_except_load(self):
+        def f(x):
+            cp = CantPickleException(x, load_fail = True)
+            raise cp
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(f, None)
+
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+
+    def test_unpickleable_raise_except_nosuper(self):
+        def f(x):
+            cp = CantPickleException(x, skip_super = True)
+            raise cp
+
+        wrenexec = pywren.default_executor()
+        fut = self.wrenexec.call_async(f, "Fun exception")
+
+        with pytest.raises(Exception) as execinfo:
+            res = fut.result() 
+            assert 'Fun exception' in str(execinfo.value)
+

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -43,6 +43,9 @@ class SimpleAsync(unittest.TestCase):
         self.assertEqual(res, np.sum(x))
 
     def test_exception(self):
+        """
+        Simple exception test
+        """
         def throwexcept(x):
             raise Exception("Throw me out!")
 
@@ -53,14 +56,6 @@ class SimpleAsync(unittest.TestCase):
             res = fut.result() 
         assert 'Throw me out!' in str(execinfo.value)
 
-
-    def test_subprocess(self):
-        def uname(x):
-            return subprocess.check_output("uname -a", shell=True)
-        
-        fut = self.wrenexec.call_async(uname, None)
-
-        res = fut.result() 
 
     def test_exception2(self):
         """
@@ -229,3 +224,4 @@ class ConfigErrors(unittest.TestCase):
                     pywren.lambda_executor(config)
                 assert 'python version' in str(excinfo.value)
                         
+


### PR DESCRIPTION
While attempting to resolve #18 I discovered that subprocess would raise an exception when invoked with a non-existant command, but that things would then fail when unpickling. Closer investigation showed that some custom python exceptions don't invoke the base class constructor and as a result they can't be unpickled. Now, pickling exceptions is a weird thing, so I guess I understand why this happens. 

To resolve, when an exception is triggered, `jobrunner.py` tries to save it and then reload it. If this fails we then save string versions of the exception and do some cleanup on the client side. It's not ideal, but an exception still propagates, which is what matters. 

Note this PR is a branch from  `release-setup` and should only be merged after. 