### PR TITLE
Function serialize cleanup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -101,12 +101,4 @@ Since it seems like lambda nodes are recycled, we can download the runtime and t
 then write a sentinel should it complete successfully. 
 
 
-###
-0. Why is it called "lambda.pickle" [issue filed]
-1. Why the heck is future and so much crap like that being shuffled along to the remote? 
-2. Why are we encoding the modules in json instead of pickling them? 
-3. Why are we failing to decode  "/Users/jonas/anaconda/lib/python2.7/email/message.py" ?
-4. Why is it being sent in the first place? 
-5. Create a test where we serialize a python module that's in UTF-8 and extended ascii
-
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -99,3 +99,14 @@ get the installed modules by running a tiny lambda
 ## Runtime
 Since it seems like lambda nodes are recycled, we can download the runtime and then cache them. Right now we'll use the hash (etag) of the runtime in s3, untar it, and
 then write a sentinel should it complete successfully. 
+
+
+###
+0. Why is it called "lambda.pickle" [issue filed]
+1. Why the heck is future and so much crap like that being shuffled along to the remote? 
+2. Why are we encoding the modules in json instead of pickling them? 
+3. Why are we failing to decode  "/Users/jonas/anaconda/lib/python2.7/email/message.py" ?
+4. Why is it being sent in the first place? 
+5. Create a test where we serialize a python module that's in UTF-8 and extended ascii
+
+

--- a/pywren/cloudpickle/preinstalls.py
+++ b/pywren/cloudpickle/preinstalls.py
@@ -316,5 +316,6 @@ modules = [
 ('scipy', False), 
 ('sklearn', False), 
 ('cvxpy', False), 
-('cvxopt', False)
+('cvxopt', False),
+('future', False)
 ]

--- a/pywren/cloudpickle/preinstalls.py
+++ b/pywren/cloudpickle/preinstalls.py
@@ -317,5 +317,10 @@ modules = [
 ('sklearn', False), 
 ('cvxpy', False), 
 ('cvxopt', False),
-('future', False)
+('future', False), 
+('six', False), 
+('glob2', False), 
+('tblib', False),
+('dill', False),
+('multiprocess', False),
 ]

--- a/pywren/jobrunner.py
+++ b/pywren/jobrunner.py
@@ -46,13 +46,13 @@ except Exception as e:
     # fails
 
     try:
-        with  open(out_filename, 'wb'), -1) as fid:
+        with  open(out_filename, 'wb') as fid:
             pickle.dump({'result' : e, 
                          'exc_type' : exc_type, 
                          'exc_value' : exc_value, 
                          'exc_traceback' : exc_traceback, 
                          'sys.path' : sys.path, 
-                         'success' : False}, fid)
+                         'success' : False}, fid, -1)
 
         # this is just to make sure they can be unpickled
         pickle.load(open(out_filename, 'rb'))

--- a/pywren/s3util.py
+++ b/pywren/s3util.py
@@ -24,7 +24,7 @@ def create_keys(bucket, prefix, callset_id, call_id):
     return data_key, output_key, status_key
 
 def create_func_key(bucket, prefix, callset_id):
-    func_key = (bucket, os.path.join(prefix, callset_id, "lambda.pickle"))
+    func_key = (bucket, os.path.join(prefix, callset_id, "func.json"))
     return func_key
 
 def create_agg_data_key(bucket, prefix, callset_id):

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -117,7 +117,7 @@ class Executor(object):
             for f in files:
                 dest_filename = f[len(pkg_root)+1:]
                 mod_str = open(f, 'rb').read()
-                module_data[f[len(pkg_root)+1:]] = unicode(mod_str, 'utf-8', errors='strict')
+                module_data[f[len(pkg_root)+1:]] = mod_str.decode('utf-8')
 
         return module_data
 

--- a/pywren/wren.py
+++ b/pywren/wren.py
@@ -116,8 +116,8 @@ class Executor(object):
                 files = [m]
             for f in files:
                 dest_filename = f[len(pkg_root)+1:]
-
-                module_data[f[len(pkg_root)+1:]] = open(f, 'r').read()
+                mod_str = open(f, 'rb').read()
+                module_data[f[len(pkg_root)+1:]] = unicode(mod_str, 'utf-8', errors='strict')
 
         return module_data
 

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -66,7 +66,10 @@ def download_runtime_if_necessary(s3conn, runtime_s3_bucket, runtime_s3_key):
     logger.debug("Expected target={}".format(expected_target))
     # check if dir is linked to correct runtime
     if os.path.exists(RUNTIME_LOC):
-        if os.path.exists(CONDA_RUNTIME_DIR):
+        if os.path.exists(CONDA_RUNTIME_DIR) :
+            if not os.path.islink(CONDA_RUNTIME_DIR):
+                raise Exception("{} is not a symbolic link, your runtime config is broken".format(CONDA_RUNTIME_DIR))
+
             existing_link = os.readlink(CONDA_RUNTIME_DIR)
             if existing_link == expected_target:
                 logger.debug("found existing {}, not re-downloading".format(ETag))
@@ -212,11 +215,13 @@ def generic_handler(event, context_dict):
             fid = open(full_filename, 'w')
             fid.write(m_text)
             fid.close()
+        logger.info("Finished writing {} module files".format(len(d['module_data'])))
         logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))
         logger.debug(subprocess.check_output("find {}".format(os.getcwd()), shell=True))
-
+        
         runtime_cached = download_runtime_if_necessary(s3, runtime_s3_bucket, 
                                                        runtime_s3_key)
+        logger.info("Runtime ready, cached={}".format(runtime_cached))
         response_status['runtime_cached'] = runtime_cached
 
         cwd = os.getcwd()

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -193,8 +193,8 @@ def generic_handler(event, context_dict):
 
         # now split
         d = json.load(open(func_filename, 'r'))
-        shutil.rmtree("/tmp/pymodules", True) # delete old modules
-        os.mkdir("/tmp/pymodules")
+        shutil.rmtree(PYTHON_MODULE_PATH, True) # delete old modules
+        os.mkdir(PYTHON_MODULE_PATH)
         # get modules and save
         for m_filename, m_text in d['module_data'].items():
             m_path = os.path.dirname(m_filename)

--- a/pywren/wrenhandler.py
+++ b/pywren/wrenhandler.py
@@ -212,8 +212,8 @@ def generic_handler(event, context_dict):
                     raise e
             full_filename = os.path.join(to_make, os.path.basename(m_filename))
             #print "creating", full_filename
-            fid = open(full_filename, 'w')
-            fid.write(m_text)
+            fid = open(full_filename, 'wb')
+            fid.write(m_text.encode('utf-8'))
             fid.close()
         logger.info("Finished writing {} module files".format(len(d['module_data'])))
         logger.debug(subprocess.check_output("find {}".format(PYTHON_MODULE_PATH), shell=True))

--- a/tests/extmoduleutf8.py
+++ b/tests/extmoduleutf8.py
@@ -1,9 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+TEST_STR = "ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹ"
+def unicode_str(x):
+    return TEST_STR
 
 
 
-# For some reason I don't understand this character is in anaconda/lib/python2.7/email/message.py and causes all sorts of headaches
 
 def foo_add(x):
+    
     return x+1
+
+# For some reason I don't understand this character is in anaconda/lib/python2.7/email/message.py and causes all sorts of headaches. including it here as a safety check
 
 

--- a/tests/extmoduleutf8.py
+++ b/tests/extmoduleutf8.py
@@ -1,0 +1,9 @@
+
+
+
+# For some reason I don't understand this character is in anaconda/lib/python2.7/email/message.py and causes all sorts of headaches
+
+def foo_add(x):
+    return x+1
+
+

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -10,6 +10,8 @@ import unittest
 import numpy as np
 import extmodule
 import extmoduleutf8
+from pywren.cloudpickle import serialize
+from pywren import wrenconfig, wrenutil, runtime
 
 class SimpleAsync(unittest.TestCase):
 
@@ -77,3 +79,25 @@ class DummyExecutorImport(unittest.TestCase):
 
         res = fut.result() 
         self.assertEqual(res, extmoduleutf8.TEST_STR)
+
+class SerializeTest(unittest.TestCase):
+    def test_simple(x):
+
+        def func(x):
+            return x + 1
+        data = range(5)
+
+        serializer = serialize.SerializeIndependent()
+        func_and_data_ser, mod_paths = serializer([func] + data)
+        for m in mod_paths:
+            print m
+
+        config =  pywren.wrenconfig.default()
+
+        runtime_bucket = config['runtime']['s3_bucket']
+        runtime_key =  config['runtime']['s3_key']
+        info = runtime.get_runtime_info(runtime_bucket, runtime_key)
+        print(info.keys())
+        for f in info['pkg_ver_list']:
+            print f[0]
+

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -34,20 +34,16 @@ class SimpleAsync(unittest.TestCase):
         x = 1.0
         fut = self.wrenexec.call_async(foo, x)
         
-        self.wrenexec.invoker.run_jobs()
-
         res = fut.result() 
         self.assertEqual(res, 2.0)
 
-    def test_utf8_string(self):
+    def test_utf8_str(self):
         def foo(x):
             return extmoduleutf8.unicode_str(x)
 
         x = 1.0
         fut = self.wrenexec.call_async(foo, x)
         
-        self.wrenexec.invoker.run_jobs()
-
         res = fut.result() 
         self.assertEqual(res, extmoduleutf8.TEST_STR)
 
@@ -69,3 +65,15 @@ class DummyExecutorImport(unittest.TestCase):
 
         res = fut.result() 
         self.assertEqual(res, 2.0)
+
+    def test_utf8_str(self):
+        def foo(x):
+            return extmoduleutf8.unicode_str(x)
+
+        x = 1.0
+        fut = self.wrenexec.call_async(foo, x)
+        
+        self.wrenexec.invoker.run_jobs()
+
+        res = fut.result() 
+        self.assertEqual(res, extmoduleutf8.TEST_STR)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -3,15 +3,9 @@ Test our ability to import other modules
 
 """
 
-import pytest
-import time
-import boto3 
-import uuid
 import numpy as np
-import time
 import pywren
 import subprocess
-import logging
 import unittest
 import numpy as np
 import extmodule
@@ -31,3 +25,25 @@ class SimpleAsync(unittest.TestCase):
 
         res = fut.result() 
         self.assertEqual(res, 2.0)
+
+    def test_utf8_module(self):
+        pass
+
+class DummyExecutorImport(unittest.TestCase):
+
+    def setUp(self):
+        self.wrenexec = pywren.dummy_executor()
+
+    def test_simple(self):
+
+        def sum_list(x):
+            print("running sumlist")
+            return np.sum(x)
+
+        x = np.arange(10)
+        fut = self.wrenexec.call_async(sum_list, x)
+        
+        self.wrenexec.invoker.run_jobs()
+
+        res = fut.result() 
+        self.assertEqual(res, np.sum(x))

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -85,7 +85,7 @@ class SerializeTest(unittest.TestCase):
 
         def func(x):
             return x + 1
-        data = range(5)
+        data = list(range(5))
 
         serializer = serialize.SerializeIndependent()
         func_and_data_ser, mod_paths = serializer([func] + data)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -90,7 +90,7 @@ class SerializeTest(unittest.TestCase):
         serializer = serialize.SerializeIndependent()
         func_and_data_ser, mod_paths = serializer([func] + data)
         for m in mod_paths:
-            print m
+            print(m)
 
         config =  pywren.wrenconfig.default()
 
@@ -99,5 +99,5 @@ class SerializeTest(unittest.TestCase):
         info = runtime.get_runtime_info(runtime_bucket, runtime_key)
         print(info.keys())
         for f in info['pkg_ver_list']:
-            print f[0]
+            print(f[0])
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -9,6 +9,7 @@ import subprocess
 import unittest
 import numpy as np
 import extmodule
+import extmoduleutf8
 
 class SimpleAsync(unittest.TestCase):
 
@@ -36,14 +37,14 @@ class DummyExecutorImport(unittest.TestCase):
 
     def test_simple(self):
 
-        def sum_list(x):
-            print("running sumlist")
-            return np.sum(x)
+        def foo(x):
+            return extmoduleutf8.foo_add(x)
 
-        x = np.arange(10)
-        fut = self.wrenexec.call_async(sum_list, x)
+
+        x = 1.0
+        fut = self.wrenexec.call_async(foo, x)
         
         self.wrenexec.invoker.run_jobs()
 
         res = fut.result() 
-        self.assertEqual(res, np.sum(x))
+        self.assertEqual(res, 2.0)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -28,7 +28,29 @@ class SimpleAsync(unittest.TestCase):
         self.assertEqual(res, 2.0)
 
     def test_utf8_module(self):
-        pass
+        def foo(x):
+            return extmoduleutf8.foo_add(x)
+
+        x = 1.0
+        fut = self.wrenexec.call_async(foo, x)
+        
+        self.wrenexec.invoker.run_jobs()
+
+        res = fut.result() 
+        self.assertEqual(res, 2.0)
+
+    def test_utf8_string(self):
+        def foo(x):
+            return extmoduleutf8.unicode_str(x)
+
+        x = 1.0
+        fut = self.wrenexec.call_async(foo, x)
+        
+        self.wrenexec.invoker.run_jobs()
+
+        res = fut.result() 
+        self.assertEqual(res, extmoduleutf8.TEST_STR)
+
 
 class DummyExecutorImport(unittest.TestCase):
 
@@ -39,7 +61,6 @@ class DummyExecutorImport(unittest.TestCase):
 
         def foo(x):
             return extmoduleutf8.foo_add(x)
-
 
         x = 1.0
         fut = self.wrenexec.call_async(foo, x)


### PR DESCRIPTION
This is a bit of a big one, around job serialization issues that we found earlier: 
1. Switch to making sure we properly utf-8 encode the python modules that we're sending to lambda. Added some tests to make sure we don't break this in the fuutre. 
2. Replaced some hard-coded paths, some old key names, etc. 
3. Updated the list of modules included in the runtime. 


closes #48, #49 , #53 